### PR TITLE
Adding check that path is a group for ls.

### DIFF
--- a/h5sh
+++ b/h5sh
@@ -226,9 +226,15 @@ class H5Shell(cmd.Cmd):
       # the path to the current group
       path = self.abspath(arg)
 
+      path_node = self.f[path]
+      # Check to make sure path is a group
+      if not isinstance(path_node, h5py.Group):
+         print('ls: {} is not a group'.format(arg))
+         return
+
       # Check to make sure path is in file
       if path in self.f:
-         nodes = list(self.f[path].values())
+         nodes = list(path_node.values())
       else:
          print('ls: {}: No such group'.format(arg))
          return


### PR DESCRIPTION
`ls` causes the shell to exit w/ error when used on a non-group. This will notify user and continue operation.
