### PR TITLE
Adding alias table capability.

### DIFF
--- a/h5sh
+++ b/h5sh
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import argparse
 import cmd
+import imp
 import os
 import readline
 import shlex
@@ -22,6 +23,12 @@ else:
 
 directory = lambda s: BLUE + BOLD + s + ENDC + ENDC
 
+_alias_table = {}
+try:
+   h5rc = imp.load_source('h5rc', os.getenv('HOME') + '/.h5rc')
+   _alias_table = h5rc.aliases
+except (FileNotFoundError, AttributeError):
+   pass
 
 class H5Shell(cmd.Cmd):
    """Line-oriented interpreter framework for HDF5 files."""
@@ -483,6 +490,13 @@ class H5Shell(cmd.Cmd):
 
    def help_rm(self):
       print('Remove a dataset or group')
+
+   def default(self, line):
+      cmd, arg, line = self.parseline(line)
+      try:
+         getattr(self, "do_" + _alias_table[cmd])(arg)
+      except:
+         super().default(line)
 
 
 if __name__ == '__main__':

--- a/h5sh
+++ b/h5sh
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import argparse
 import cmd
+from configparser import ConfigParser
 import imp
 import os
 import readline
@@ -23,12 +24,8 @@ else:
 
 directory = lambda s: BLUE + BOLD + s + ENDC + ENDC
 
-_alias_table = {}
-try:
-   h5rc = imp.load_source('h5rc', os.getenv('HOME') + '/.h5rc')
-   _alias_table = h5rc.aliases
-except (FileNotFoundError, AttributeError):
-   pass
+config = ConfigParser()
+config.read(os.getenv('HOME') + '/.h5rc')
 
 class H5Shell(cmd.Cmd):
    """Line-oriented interpreter framework for HDF5 files."""
@@ -55,6 +52,13 @@ class H5Shell(cmd.Cmd):
       delims = delims.replace('/', '')
       delims = delims.replace(',', '')
       readline.set_completer_delims(delims)
+
+      self.alias_table = {}
+      try:
+         self.alias_table = config['ALIASES']
+      except KeyError:
+         pass
+
 
    def abspath(self, path=''):
       """Absolute path in HDF5 file
@@ -494,7 +498,7 @@ class H5Shell(cmd.Cmd):
    def default(self, line):
       cmd, arg, line = self.parseline(line)
       try:
-         getattr(self, "do_" + _alias_table[cmd])(arg)
+         getattr(self, "do_" + self.alias_table[cmd])(arg)
       except:
          super().default(line)
 


### PR DESCRIPTION
I'm helplessly hooked on my bash aliases, `l` for `ls` in particular. This PR allows one to have a `.h5rc` file in their home directory with a dictionary of aliases for existing commands in `h5sh`. Right now mine contains

```bash
# ALIASES
aliases = {'l' : 'ls'}
```

It probably won't be terribly useful until more commands are added, but it's a start for now.